### PR TITLE
chore():Lint code and fix warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following types are supported:
 * `:boolean` (e.g. '0'/'1', 'f'/'t', 'false'/'true', 'off'/'on', 'no'/'yes' for resp. false and true)
 * `:integer`
 * `:float`
+* `:json`
 * `:symbol`
 * `:date` (e.g. '2014-3-26')
 * `:time` (e.g. '14:00')

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The following types are supported:
 * `:hash` (e.g. 'a=1&b=2' becomes `{'a' => '1', 'b' => '2'}`)
 * `:array` (e.g. 'tag1,tag2' becomes `['tag1', 'tag2']`)
 * `:uri` (e.g. 'http://www.google.com' becomes result of `URI.parse('http://www.google.com')`)
+* `:uuid`
 
 ### Groups
 

--- a/lib/envied/coercer.rb
+++ b/lib/envied/coercer.rb
@@ -22,7 +22,7 @@ class ENVied::Coercer
 
   def self.supported_types
     @supported_types ||= begin
-      [:hash, :array, :time, :date, :symbol, :boolean, :integer, :string, :uri, :float, :json].sort
+      [:hash, :array, :time, :date, :symbol, :boolean, :integer, :string, :uri, :uuid, :float, :json].sort
     end
   end
 

--- a/lib/envied/coercer.rb
+++ b/lib/envied/coercer.rb
@@ -22,7 +22,7 @@ class ENVied::Coercer
 
   def self.supported_types
     @supported_types ||= begin
-      [:hash, :array, :time, :date, :symbol, :boolean, :integer, :string, :uri, :float].sort
+      [:hash, :array, :time, :date, :symbol, :boolean, :integer, :string, :uri, :float, :json].sort
     end
   end
 

--- a/lib/envied/coercer/envied_string.rb
+++ b/lib/envied/coercer/envied_string.rb
@@ -61,6 +61,17 @@ class ENVied::Coercer::ENViedString
     raise_unsupported_coercion(str, __method__)
   end
 
+  def to_json(str)
+    require 'json'
+    if str.is_a?(String) && str.first == '{' && str.last == '}'
+      JSON.parse(str)
+    else
+      raise_unsupported_coercion(str, __method__)
+    end
+  rescue JSON::ParserError
+    raise_unsupported_coercion(str, __method__)
+  end
+
   private
 
   def raise_unsupported_coercion(value, method)

--- a/lib/envied/coercer/envied_string.rb
+++ b/lib/envied/coercer/envied_string.rb
@@ -2,6 +2,7 @@ class ENVied::Coercer::ENViedString
   TRUE_VALUES = %w[1 on t true y yes].freeze
   FALSE_VALUES = %w[0 off f false n no].freeze
   BOOLEAN_MAP = (TRUE_VALUES.product([ true ]) + FALSE_VALUES.product([ false ])).to_h.freeze
+  UUID_REGEXP = /\A[0-9a-f]{8}-(:?[0-9a-f]{4}-){3}[0-9a-f]{12}\z/i.freeze
 
   def to_array(str)
     str.split(/(?<!\\),/).map{|i| i.gsub(/\\,/,',') }
@@ -70,6 +71,14 @@ class ENVied::Coercer::ENViedString
     end
   rescue JSON::ParserError
     raise_unsupported_coercion(str, __method__)
+  end
+
+  def to_uuid(str)
+    if UUID_REGEXP.match?(str)
+      str
+    else
+      raise_unsupported_coercion(str, __method__)
+    end
   end
 
   private

--- a/spec/coercer_spec.rb
+++ b/spec/coercer_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe ENVied::Coercer do
 
   describe '.supported_types' do
     it 'returns a sorted set of supported types' do
-      expect(described_class.supported_types).to eq %i(array boolean date float hash integer json string symbol time uri)
+      expect(described_class.supported_types).to eq %i(array boolean date float hash integer json string symbol time uri uuid)
     end
   end
 
   describe '.supported_type?' do
     it 'returns true for supported type' do
-      %i(array boolean date float hash integer json string symbol time uri).each do |type|
+      %i(array boolean date float hash integer json string symbol time uri uuid).each do |type|
         expect(described_class.supported_type?(type)).to eq true
       end
     end
@@ -180,6 +180,20 @@ RSpec.describe ENVied::Coercer do
       it 'fails with invalid json' do
         ['', 'nil', '2021-04-17', '{"foo"}'].each do |value|
           expect { coerce(value, :json) }.to raise_error(ENVied::Coercer::UnsupportedCoercion)
+        end
+      end
+    end
+
+    describe 'to uuid' do
+      it 'accepts valid UUIDs' do
+        %w[c616eeb6-2244-4be4-a9f8-c67c29768109 4f0bf594-b08d-4bf2-9ba1-ae64c48523de].each do |value|
+          expect(coerce(value, :uuid)).to be_kind_of(String)
+        end
+      end
+
+      it 'fails with an invalid UUIDs' do
+        %w[abc 123 error].each do |value|
+          expect { coerce(value, :uuid) }.to raise_error(ENVied::Coercer::UnsupportedCoercion)
         end
       end
     end

--- a/spec/coercer_spec.rb
+++ b/spec/coercer_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe ENVied::Coercer do
 
   describe '.supported_types' do
     it 'returns a sorted set of supported types' do
-      expect(described_class.supported_types).to eq %i(array boolean date float hash integer string symbol time uri)
+      expect(described_class.supported_types).to eq %i(array boolean date float hash integer json string symbol time uri)
     end
   end
 
   describe '.supported_type?' do
     it 'returns true for supported type' do
-      %i(array boolean date float hash integer string symbol time uri).each do |type|
+      %i(array boolean date float hash integer json string symbol time uri).each do |type|
         expect(described_class.supported_type?(type)).to eq true
       end
     end
@@ -160,6 +160,27 @@ RSpec.describe ENVied::Coercer do
 
       it 'fails when string starts with e' do
         expect { coerce('e1', :float) }.to raise_error(ENVied::Coercer::UnsupportedCoercion)
+      end
+    end
+
+    describe 'to json' do
+      {'{}'=>{}, '{"a": 1}'=>{"a"=>1}}.each do |value, parsed|
+        it "converts #{value} to a parsed JSON" do
+          expect(coerce(value, :float)).to be_kind_of(Hash)
+          expect(coerce(value, :json)).to eq parsed
+        end
+      end
+
+      it 'fails with json that is not enclosed in {}' do
+        ['null', 'true', 'false', '1'].each do |value|
+          expect { coerce(value, :json) }.to raise_error(ENVied::Coercer::UnsupportedCoercion)
+        end
+      end
+
+      it 'fails with invalid json' do
+        ['', 'nil', '2021-04-17', '{"foo"}'].each do |value|
+          expect { coerce(value, :json) }.to raise_error(ENVied::Coercer::UnsupportedCoercion)
+        end
       end
     end
 


### PR DESCRIPTION
# Description
In api-v2 initialization there's a warning about line 56 of envied.rb `warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`

# Changes
- Lint code using Rubocop
- Fix line 56 warning